### PR TITLE
feat: add initial EKS module using terraform-aws-eks

### DIFF
--- a/eks/main.tf
+++ b/eks/main.tf
@@ -1,0 +1,28 @@
+module "eks" {
+  source          = "terraform-aws-modules/eks/aws"
+  version         = "20.8.4"
+
+  cluster_name    = var.cluster_name
+  cluster_version = var.kubernetes_version
+  subnet_ids      = var.subnet_ids
+  vpc_id          = var.vpc_id
+
+  enable_irsa     = true
+
+  eks_managed_node_groups = {
+    default = {
+      desired_size = 2
+      max_size     = 3
+      min_size     = 1
+
+      instance_types = ["t3.medium"]
+      capacity_type  = "ON_DEMAND"
+    }
+  }
+
+  tags = {
+    Environment = var.environment
+    Project     = "terraform-k8s-aws-cluster"
+  }
+}
+

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -1,0 +1,15 @@
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint for EKS control plane"
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_security_group_id" {
+  description = "Security group ID attached to the EKS cluster"
+  value       = module.eks.cluster_security_group_id
+}
+

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -1,0 +1,26 @@
+variable "cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version"
+  type        = string
+  default     = "1.29"
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs"
+  type        = list(string)
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g., dev, prod)"
+  type        = string
+}
+


### PR DESCRIPTION
This PR introduces the initial implementation of the EKS module using the official `terraform-aws-eks` module. It includes:

- Base configuration for the EKS cluster
- Managed node group (on-demand t3.medium)
- Essential input variables (e.g., VPC ID, subnet IDs, cluster name)
- Basic outputs for cluster name, endpoint, and security group ID

More features like cluster logging, addons, and IRSA improvements will be added in future pull requests.
