### PR TITLE
Add Kubernetes YAML templates for deployments, services, ingress, and…

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,13 @@
+# Kubernetes YAML Templates
+
+This folder provides basic YAML configuration templates for deploying applications on EKS clusters.
+
+## Structure
+
+- `deployments/` – Deployment examples
+- `services/` – Service types (ClusterIP, NodePort, LoadBalancer)
+- `ingress/` – Ingress resource examples
+- `hpa/` – Horizontal Pod Autoscaler (HPA) examples
+
+These templates are generic and should be adjusted to match your application's context.
+

--- a/templates/deployments/sample-deployment.yaml
+++ b/templates/deployments/sample-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  labels:
+    app: my-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - name: my-app
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+

--- a/templates/hpa/sample-hpa.yaml
+++ b/templates/hpa/sample-hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: my-app-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: my-app
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+

--- a/templates/ingress/sample-ingress.yaml
+++ b/templates/ingress/sample-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-app-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - host: myapp.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: my-app-service
+                port:
+                  number: 80
+

--- a/templates/services/sample-service.yaml
+++ b/templates/services/sample-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app-service
+spec:
+  type: ClusterIP
+  selector:
+    app: my-app
+  ports:
+    - port: 80
+      targetPort: 80
+


### PR DESCRIPTION
This pull request introduces a new folder named `templates/` to organize reusable Kubernetes YAML configurations. The goal is to provide basic examples for deploying workloads to EKS clusters created by this Terraform module.

Included in this PR:
- Deployment template using nginx
- ClusterIP Service template
- Ingress resource with a rewrite-target annotation
- Horizontal Pod Autoscaler (HPA) configuration
- Documentation in `templates/README.md` explaining the purpose and structure

These templates serve as references and can be adjusted to fit specific applications.
